### PR TITLE
Enhance MCP Discovery with Network Management Capability Metadata

### DIFF
--- a/draft-yang-nmrg-mcp-nm.md
+++ b/draft-yang-nmrg-mcp-nm.md
@@ -399,6 +399,38 @@ Step 3: The MCP Client request authorization from the MCP server.
 
 Step 4: The MCP Client invoke specific tools with authorization.
 
+## Network Management Capability Metadata
+
+In MCP-based network management environments, exposed tools may
+represent operationally sensitive network management actions,
+including telemetry retrieval, diagnostics, configuration
+modification, service provisioning, policy updates, or device
+control operations. While the MCP repository maintains information
+about MCP servers, tools, and capabilities, additional
+network-management-specific capability metadata may improve
+operational safety, interoperability, and automated decision-making.
+
+MCP repositories and MCP servers may associate tools with metadata
+describing the operational characteristics and constraints of the
+exposed capability. Such metadata may include the operation type,
+operational scope, supported management protocols, authorization
+requirements, rollback support capability, operational risk level,
+capability freshness timestamp, synchronization status, and human
+approval requirements for high-impact operations. This information
+may assist MCP clients, AI agents, and orchestration systems in
+evaluating the suitability, applicability, and operational safety of
+a tool prior to authorization and invocation.
+
+Capability metadata may additionally help reduce unsafe or unintended
+operations by enabling MCP clients and AI agents to better understand
+the operational constraints associated with network management
+actions. Capability freshness information may assist in avoiding
+stale, outdated, or unreachable MCP services in large-scale
+distributed network management deployments. Operational risk
+classification may further support policy-driven execution workflows,
+including human-in-the-loop approval mechanisms for service-impacting
+or irreversible operations.
+
 # Deployment Consideration in adopting MCP in the Network Management
 
 This section describes MCP deployment requirements for network management environments,

--- a/draft-yang-nmrg-mcp-nm.md
+++ b/draft-yang-nmrg-mcp-nm.md
@@ -412,12 +412,15 @@ operational safety, interoperability, and automated decision-making.
 
 MCP repositories and MCP servers may associate tools with metadata
 describing both functional capabilities and operational constraints
-of the exposed capability. Functional capability metadata may
-include operation type, operational scope, supported management
-protocols, rollback support capability, and operational risk level.
-Operational constraint metadata may include authorization
-requirements, human approval requirements, freshness indicators, and
-synchronization version information.
+of the exposed capability as follows:
+
+- Functional capability metadata:
+  operation type, operational scope, supported management
+  protocols, rollback support capability, and operational risk level.
+
+- Operational constraint metadata
+  authorization requirements, human approval requirements, freshness indicators, and
+  synchronization version information.
 
 Such metadata may assist MCP clients, AI agents, and orchestration
 systems in evaluating the suitability, applicability, and

--- a/draft-yang-nmrg-mcp-nm.md
+++ b/draft-yang-nmrg-mcp-nm.md
@@ -411,25 +411,19 @@ network-management-specific capability metadata may improve
 operational safety, interoperability, and automated decision-making.
 
 MCP repositories and MCP servers may associate tools with metadata
-describing the operational characteristics and constraints of the
-exposed capability. Such metadata may include the operation type,
-operational scope, supported management protocols, authorization
-requirements, rollback support capability, operational risk level,
-capability freshness timestamp, synchronization status, and human
-approval requirements for high-impact operations. This information
-may assist MCP clients, AI agents, and orchestration systems in
-evaluating the suitability, applicability, and operational safety of
-a tool prior to authorization and invocation.
+describing both functional capabilities and operational constraints
+of the exposed capability. Functional capability metadata may
+include operation type, operational scope, supported management
+protocols, rollback support capability, and operational risk level.
+Operational constraint metadata may include authorization
+requirements, human approval requirements, freshness indicators, and
+synchronization version information.
 
-Capability metadata may additionally help reduce unsafe or unintended
-operations by enabling MCP clients and AI agents to better understand
-the operational constraints associated with network management
-actions. Capability freshness information may assist in avoiding
-stale, outdated, or unreachable MCP services in large-scale
-distributed network management deployments. Operational risk
-classification may further support policy-driven execution workflows,
-including human-in-the-loop approval mechanisms for service-impacting
-or irreversible operations.
+Such metadata may assist MCP clients, AI agents, and orchestration
+systems in evaluating the suitability, applicability, and
+operational safety of MCP tools prior to authorization and
+invocation, particularly in large-scale distributed network
+management deployments.
 
 # Deployment Consideration in adopting MCP in the Network Management
 


### PR DESCRIPTION
This PR proposes additional network-management-specific capability metadata for MCP-exposed tools and services within distributed MCP-based network management environments.

Resolves https://github.com/Yuanyuan4666/Integration-of-MCP-and-Network-Management-Protocols/issues/18